### PR TITLE
fix: homepageの設定を正しいものに変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "drip-official-dev",
   "version": "0.1.0",
-  "homepage": "https://drip-pages.github.io/drip-official-dev/",
+  "homepage": "https://drip.drecom.co.jp/",
   "private": true,
   "dependencies": {
     "@material-ui/icons": "^4.2.1",


### PR DESCRIPTION
# WHY
package.jsonに書かれているURLがdevelopのものだった。
このままbuildするとcssが適用されないドリップページが生成される
# HOW
本番用のURLに書き換えた。

close #25 