### PR TITLE
fix: manifest.jsonにReactAppの文字があったため、これをDRIPに変更しておく

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "DRIP",
+  "name": "DRIP - Drecom Invention Project",
   "icons": [
     {
       "src": "favicon.ico",


### PR DESCRIPTION
# 目的
manifest.jsonにデフォルト値である「React App」の文字が入っている。
このmanifest.jsonは表層に出ないものの、アクセス者にダウンロードされるため、適切な文字に変更する

# 解決手法
React APP -> DRIP
Create React App Sample -> DRIP - Drecom Invention Project
に変更する。