### PR TITLE
add: .envファイルを追加し、*.jsファイルに対して*.mapファイルが生成されないように設定文を追加

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+GENERATE_SOURCEMAP=false


### PR DESCRIPTION
#18 
# 目的
*.jsに対して*.mapファイルがビルド時に生成されてしまう。
*.mapは逆コンパイルできてしまうため、基本的には削除したい
https://code-log.hatenablog.com/entry/2019/03/18/111559

# 解決手法
`.env`ファイルを生成して、生成されないように設定文を書き加える