### PR TITLE
fix: safariでもメンバーがセンタリングするように

### DIFF
--- a/src/components/Team/Team.scss
+++ b/src/components/Team/Team.scss
@@ -4,9 +4,12 @@
     text-align: center;
   }
   .member-area {
+    display: -webkit-flex;
     display: flex;
+    -webkit-justify-content: center;
     justify-content: center;
     flex-wrap: wrap;
+    align-items: center;
     align-content: center;
 
     .member-icon {


### PR DESCRIPTION
close #60 
# 目的
開発環境からコピーし忘れコードを写してくる

# 解決手法
https://github.com/drip-pages/drip-official-dev/commit/de87c5f95791b032858293e870a75176670c3bf0
のコピペ