### PR TITLE
add: reduxの導入

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,15 @@
   "dependencies": {
     "@material-ui/icons": "^4.2.1",
     "@types/node": "^12.6.8",
+    "@types/react-redux": "^7.1.3",
     "eslint-utils": "1.4.1",
     "lodash": "4.17.14",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
+    "react-redux": "^7.1.1",
     "react-router-dom": "^5.0.1",
-    "react-scripts": "3.0.1"
+    "react-scripts": "3.0.1",
+    "redux": "^4.0.4"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import './App.scss'
 import { Switch, Route, BrowserRouter } from 'react-router-dom'
 import Header from './components/Header'
@@ -11,30 +11,16 @@ import HelmetWrap from './components/HelmetWrap'
 import ScrollToTop from './components/ScrollToTop'
 
 function App() {
-  const [show, setShow] = useState(false)
   return (
     <div className="App">
       <HelmetWrap />
       <BrowserRouter basename={process.env.PUBLIC_URL}>
         <ScrollToTop>
-          <Header
-            toogleShowAccordionMenu={() => {
-              show ? setShow(false) : setShow(true)
-            }}
-            showMenu={show}
-          />
+          <Header />
           <Switch>
-            <Route
-              exact
-              path="/"
-              render={() => <Home items={NewsItems} onInit={() => setShow(false)} languageJa={true} />}
-            />
-            <Route path="/news" render={() => <News items={NewsItems} onInit={() => setShow(false)} />} />
-            <Route
-              exact
-              path="/en"
-              render={() => <Home items={NewsItems} onInit={() => setShow(false)} languageJa={false} />}
-            />
+            <Route exact path="/" render={() => <Home items={NewsItems} languageJa={true} />} />
+            <Route path="/news" render={() => <News items={NewsItems} />} />
+            <Route exact path="/en" render={() => <Home items={NewsItems} languageJa={false} />} />
             <Route component={PageNotFound} />
           </Switch>
           <Footer />

--- a/src/actions/header.tsx
+++ b/src/actions/header.tsx
@@ -1,0 +1,21 @@
+import { Action } from 'redux'
+
+export enum ActionTypes {
+  SET_IS_SHOW_MENU = '@Drip/header/SET_IS_SHOW_MENU',
+}
+
+interface SetIsShowMenu extends Action {
+  type: ActionTypes.SET_IS_SHOW_MENU
+  payload: {
+    isShowMenu: boolean
+  }
+}
+
+export const setIsShowMenu = (isShowMenu: boolean): SetIsShowMenu => ({
+  type: ActionTypes.SET_IS_SHOW_MENU,
+  payload: {
+    isShowMenu,
+  },
+})
+
+export type HeaderActions = SetIsShowMenu

--- a/src/components/HamburgerButton/HamburgerButton.scss
+++ b/src/components/HamburgerButton/HamburgerButton.scss
@@ -1,5 +1,5 @@
 @import "../../utils/vars.scss";
-.HurgerButton {
+.HamburgerButton {
   display: inline-block;
   width: 30px;
   height: 30px;

--- a/src/components/HamburgerButton/index.tsx
+++ b/src/components/HamburgerButton/index.tsx
@@ -1,26 +1,26 @@
 import React from 'react'
-import './HurgerButton.scss'
+import './HamburgerButton.scss'
 import { ReactComponent as ThreeLine } from '../../img/threeLine.svg'
 import { ReactComponent as Batsu } from '../../img/batsu.svg'
 
-type HurgerButtonProps = {
+type HamburgerButtonProps = {
   onClick: () => void
   show: boolean
 }
 
-class HurgerButton extends React.Component<HurgerButtonProps, {}> {
-  handleHurgerButtonClick = () => {
+class HamburgerButton extends React.Component<HamburgerButtonProps, {}> {
+  handleHamburgerButtonClick = () => {
     this.props.onClick()
   }
 
   render() {
     const { show } = this.props
     return (
-      <span className="HurgerButton" onClick={this.handleHurgerButtonClick}>
+      <span className="HamburgerButton" onClick={this.handleHamburgerButtonClick}>
         {show ? <Batsu /> : <ThreeLine />}
       </span>
     )
   }
 }
 
-export default HurgerButton
+export default HamburgerButton

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -3,23 +3,25 @@ import headerLogo from '../../img/navi.png'
 import './Header.scss'
 import classNames from 'classnames'
 import { Link, RouteComponentProps, withRouter } from 'react-router-dom'
-import HurgerButton from '../HurgerButton'
+import HamburgerButton from '../HamburgerButton'
 import { Translation } from 'react-i18next'
 import i18n from 'i18next'
+import { connect } from 'react-redux'
+import { ReduxState } from '../../reducers'
+import { Action, Dispatch } from 'redux'
+import { setIsShowMenu } from '../../actions/header'
 
-type HeaderProps = {
-  showMenu: boolean
-  toogleShowAccordionMenu: () => void
-} & RouteComponentProps
-
-type HeaderState = {
-  value: number
+type MapDispatchToProps = {
+  setIsShowMenu: (isShowMenu: boolean) => void
 }
-class Header extends React.Component<HeaderProps, HeaderState> {
-  state = {
-    value: 0,
-  }
 
+type MapStateToProps = {
+  isShowMenu: boolean
+}
+
+type HeaderProps = RouteComponentProps & MapDispatchToProps & MapStateToProps
+
+class Header extends React.Component<HeaderProps> {
   constructor(props: HeaderProps) {
     super(props)
     if (this.props.location.pathname === '/en') {
@@ -28,11 +30,12 @@ class Header extends React.Component<HeaderProps, HeaderState> {
   }
 
   handleMenuButton = () => {
-    this.props.toogleShowAccordionMenu()
+    const { isShowMenu, setIsShowMenu } = this.props
+    isShowMenu ? setIsShowMenu(false) : setIsShowMenu(true)
   }
 
   render() {
-    const { showMenu } = this.props
+    const { isShowMenu } = this.props
     return (
       <div className="Header">
         <div className="fixed-area">
@@ -42,7 +45,7 @@ class Header extends React.Component<HeaderProps, HeaderState> {
             </Link>
             <span className="menu-area">
               <span className="native-button">
-                <HurgerButton onClick={this.handleMenuButton} show={showMenu} />
+                <HamburgerButton onClick={this.handleMenuButton} show={isShowMenu} />
               </span>
 
               <span className="non-native-buttons">
@@ -63,7 +66,7 @@ class Header extends React.Component<HeaderProps, HeaderState> {
               </span>
             </span>
           </div>
-          <ul className={classNames('underMenu', { show: showMenu })}>
+          <ul className={classNames('underMenu', { show: isShowMenu })}>
             <Link to="/news">
               <li className="item">News</li>
             </Link>
@@ -86,4 +89,15 @@ class Header extends React.Component<HeaderProps, HeaderState> {
   }
 }
 
-export default withRouter(Header)
+const mapStateToProps: (state: ReduxState) => MapStateToProps = state => ({
+  isShowMenu: state.header.isShowMenu,
+})
+
+const mapDispatchToProps: (dispatch: Dispatch<Action>) => MapDispatchToProps = dispatch => ({
+  setIsShowMenu: isShowMenu => dispatch(setIsShowMenu(isShowMenu)),
+})
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(withRouter(Header))

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,18 @@ import App from './App'
 import * as serviceWorker from './serviceWorker'
 import 'bootstrap/dist/css/bootstrap.min.css' // React bootstrap用
 import './utils/i18n' // for translation
-ReactDOM.render(<App />, document.getElementById('root'))
+import { Store, Action, createStore } from 'redux'
+import { createReducers, ReduxState } from './reducers'
+import { Provider } from 'react-redux'
+
+const store: Store<ReduxState, Action> = createStore(createReducers())
+
+const rootComponent: JSX.Element = (
+  <Provider store={store}>
+    <App />
+  </Provider>
+)
+ReactDOM.render(rootComponent, document.getElementById('root'))
 
 // オフラインにて読み込みを早くしたい場合、regisuter()をunregister()に変更してください。
 // ただし、いくつかの注意点があります。: https://bit.ly/CRA-PWA

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -6,10 +6,16 @@ import OurInvention from '../../components/OurInvention'
 import Team from '../../components/Team'
 import ContactUs from '../../components/ContactUs'
 import i18n from 'i18next'
+import { connect } from 'react-redux'
+import { setIsShowMenu } from '../../actions/header'
+import { Action, Dispatch } from 'redux'
 
-type HomeProps = {
+type MapDispatchToProps = {
+  setIsShowMenu: (isShowMenu: boolean) => void
+}
+
+type HomeProps = MapDispatchToProps & {
   items: any[]
-  onInit: () => void
   languageJa: boolean
 }
 
@@ -18,13 +24,14 @@ class Home extends React.Component<HomeProps, {}> {
     super(props)
     i18n.changeLanguage(this.props.languageJa ? 'ja' : 'en')
   }
+
   componentDidMount(): void {
-    this.props.onInit()
+    this.props.setIsShowMenu(false)
   }
 
   componentDidUpdate(prevProps: HomeProps): void {
     if (this.props.languageJa !== prevProps.languageJa) {
-      this.props.onInit()
+      this.props.setIsShowMenu(false)
       i18n.changeLanguage(this.props.languageJa ? 'ja' : 'en')
     }
   }
@@ -43,4 +50,11 @@ class Home extends React.Component<HomeProps, {}> {
   }
 }
 
-export default Home
+const mapDispatchToProps: (dispatch: Dispatch<Action>) => MapDispatchToProps = dispatch => ({
+  setIsShowMenu: isShowMenu => dispatch(setIsShowMenu(isShowMenu)),
+})
+
+export default connect(
+  null,
+  mapDispatchToProps
+)(Home)

--- a/src/pages/News/index.tsx
+++ b/src/pages/News/index.tsx
@@ -1,14 +1,20 @@
 import * as React from 'react'
 import NewsList from '../../components/NewsList'
+import { Action, Dispatch } from 'redux'
+import { setIsShowMenu } from '../../actions/header'
+import { connect } from 'react-redux'
 
-type NewsProps = {
-  items: any[]
-  onInit: () => void
+type MapDispatchToProps = {
+  setIsShowMenu: (isShowMenu: boolean) => void
 }
 
-class News extends React.Component<NewsProps, {}> {
+type NewsProps = MapDispatchToProps & {
+  items: any[]
+}
+
+class News extends React.Component<NewsProps> {
   componentDidMount(): void {
-    this.props.onInit()
+    this.props.setIsShowMenu(false)
   }
 
   render() {
@@ -23,4 +29,11 @@ class News extends React.Component<NewsProps, {}> {
   }
 }
 
-export default News
+const mapDispatchToProps: (dispatch: Dispatch<Action>) => MapDispatchToProps = dispatch => ({
+  setIsShowMenu: isShowMenu => dispatch(setIsShowMenu(isShowMenu)),
+})
+
+export default connect(
+  null,
+  mapDispatchToProps
+)(News)

--- a/src/reducers/header.tsx
+++ b/src/reducers/header.tsx
@@ -1,0 +1,20 @@
+import { ActionTypes, HeaderActions } from '../actions/header'
+
+export type HeaderState = {
+  isShowMenu: boolean
+}
+
+export const defaultState: HeaderState = {
+  isShowMenu: false,
+}
+
+const Header = (state: HeaderState = defaultState, action: HeaderActions) => {
+  switch (action.type) {
+    case ActionTypes.SET_IS_SHOW_MENU:
+      return { ...state, isShowMenu: action.payload.isShowMenu }
+    default:
+      return state
+  }
+}
+
+export default Header

--- a/src/reducers/index.tsx
+++ b/src/reducers/index.tsx
@@ -1,0 +1,11 @@
+import { Reducer, Action, combineReducers } from 'redux'
+import header, { HeaderState } from './header'
+
+export type ReduxState = {
+  header: HeaderState
+}
+
+export const createReducers = (): Reducer<ReduxState, Action> =>
+  combineReducers({
+    header,
+  })

--- a/yarn.lock
+++ b/yarn.lock
@@ -900,6 +900,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.5.5":
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.2.tgz#c3d6e41b304ef10dcf13777a33e7694ec4a9a6dd"
+  integrity sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.1.0", "@babel/template@^7.4.0", "@babel/template@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
@@ -1399,6 +1406,14 @@
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.2.tgz#0e670ea254d559241b6eeb3894f8754991e73220"
   integrity sha512-ui3WwXmjTaY73fOQ3/m3nnajU/Orhi6cEu5rzX+BrAAJxa3eITXZ5ch9suPqtM03OWhAHhPSyBGCN4UKoxO20Q==
 
+"@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -1459,6 +1474,16 @@
   integrity sha512-d4xhcjX5b3roNMObRNMfb1HinHQlQLPo8xlDj60dnHeeAw2bBymR2cy/l1giJpHzo/ZFgSvgVUvIWr4kCrenCg==
   dependencies:
     react-i18next "*"
+
+"@types/react-redux@^7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.3.tgz#7efc1e36267e9bf8b24ec89ac30a27a65c94cd25"
+  integrity sha512-coaQFfn6XrHF/4CSF8eBM9rUbi5TX6qVhS+KF89Z2nC9YdTKTckOpJLJyQocYLrXF0IFX+/ZUJwMvbZ0nNmkDg==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
 
 "@types/react-router-dom@^4.3.4":
   version "4.3.4"
@@ -5031,7 +5056,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.2.1:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.2.1, hoist-non-react-statics@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
   integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
@@ -8999,6 +9024,11 @@ react-is@^16.3.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
+react-is@^16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
+  integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
+
 react-overlays@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-1.2.0.tgz#205368eeb0a5fb0b7f9b717fa7a12d518500abdb"
@@ -9024,6 +9054,18 @@ react-popper@^1.3.2:
     prop-types "^15.6.1"
     typed-styles "^0.0.7"
     warning "^4.0.2"
+
+react-redux@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.1.1.tgz#ce6eee1b734a7a76e0788b3309bf78ff6b34fa0a"
+  integrity sha512-QsW0vcmVVdNQzEkrgzh2W3Ksvr8cqpAv5FhEk7tNEft+5pp7rXxAudTz3VOPawRkLIepItpkEIyLcN/VVXzjTg==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    hoist-non-react-statics "^3.3.0"
+    invariant "^2.2.4"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^16.9.0"
 
 react-router-dom@^5.0.1:
   version "5.0.1"
@@ -9261,6 +9303,14 @@ redent@^1.0.0:
   dependencies:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
+
+redux@^4.0.0, redux@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.4.tgz#4ee1aeb164b63d6a1bcc57ae4aa0b6e6fa7a3796"
+  integrity sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==
+  dependencies:
+    loose-envify "^1.4.0"
+    symbol-observable "^1.2.0"
 
 regenerate-unicode-properties@^8.0.2:
   version "8.1.0"
@@ -10321,6 +10371,11 @@ svgo@^1.0.0, svgo@^1.2.2:
     stable "^0.1.8"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
+
+symbol-observable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 symbol-tree@^3.2.2:
   version "3.2.4"


### PR DESCRIPTION
close #48 
# 目的
reactのstateだけでは状態管理が煩雑になり厳しい。
そこで、reduxを導入する。

# 解決手法
reduxを導入し、必要なディレクトリ構造の作成を行う。
また、テストとして、ヘッダーのアコーディオンメニューを開くか開かないかをReduxに持たせる

