### PR TITLE
add: gitignoreの更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 **/.DS_Store
+/node_modules/
+/build/


### PR DESCRIPTION
# 目的
https://github.com/drip-pages/drip-official/issues/51
にてbashファイルを書くにあたって、
gh-pagesにプッシュしたくないディレクトリを.gitignoreレベルで排除しておきたい。

# 解決手法
gh-pagesが管理している.gitignoreにgh-pagesにプッシュしたくないディレクトリを追記する。