### PR TITLE
add: アコーディオンメニュー以外の部分をタッチした時に消えるようにする

### DIFF
--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -73,34 +73,43 @@
       }
     }
 
-    .underMenu {
+    .underMenuArea {
       position: absolute;
-      transition: 0.5s all;
       visibility: hidden;
       opacity: 0;
       max-height: 0;
       width: 100%;
-      padding-left: 0;
-      background-color: $colorWhite;
-      box-shadow: 0 1px 1px $colorShadow;
+      transition: 0.5s all;
 
-      li {
-        padding: 0.5em 2em;
-        list-style-type: none;
-        font-size: 16px;
-        border: 1px solid $colorGray;
-        width: 100%;
+      .accordionMenu {
+        padding-left: 0;
+        transition: 0.5s all;
+        background-color: $colorWhite;
+        box-shadow: 0 1px 1px $colorShadow;
+        margin-bottom: 0;
 
-        &:hover {
-          text-decoration: underline;
+        li {
+          padding: 0.5em 2em;
+          list-style-type: none;
+          font-size: 16px;
+          border: 1px solid $colorGray;
+          width: 100%;
+
+          &:hover {
+            text-decoration: underline;
+          }
         }
       }
-
       &.show {
         transition: 0.5s all;
         visibility: visible;
         opacity: 1;
         max-height: 1000px;
+      }
+
+      .outArea {
+        position: relative;
+        padding: 100%;
       }
     }
 

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -34,6 +34,11 @@ class Header extends React.Component<HeaderProps> {
     isShowMenu ? setIsShowMenu(false) : setIsShowMenu(true)
   }
 
+  handleOutAreaClick = () => {
+    const { isShowMenu, setIsShowMenu } = this.props
+    isShowMenu && setIsShowMenu(false)
+  }
+
   render() {
     const { isShowMenu } = this.props
     return (
@@ -66,22 +71,25 @@ class Header extends React.Component<HeaderProps> {
               </span>
             </span>
           </div>
-          <ul className={classNames('underMenu', { show: isShowMenu })}>
-            <Link to="/news">
-              <li className="item">News</li>
-            </Link>
-            <a href="https://www.drecom.co.jp/company/" target="_blank" rel="noopener noreferrer">
-              <li className="item">Company</li>
-            </a>
-            <a href="https://goo.gl/forms/my00T6ZbZK" target="_blank" rel="noopener noreferrer">
-              <li className="item">Contact</li>
-            </a>
-            <Link to={i18n.language === 'ja' ? '/en' : '/'}>
-              <li className="item">
-                <Translation>{t => t('headerButton')}</Translation>
-              </li>
-            </Link>
-          </ul>
+          <div className={classNames('underMenuArea', { show: isShowMenu })}>
+            <ul className="accordionMenu">
+              <Link to="/news">
+                <li className="item">News</li>
+              </Link>
+              <a href="https://www.drecom.co.jp/company/" target="_blank" rel="noopener noreferrer">
+                <li className="item">Company</li>
+              </a>
+              <a href="https://goo.gl/forms/my00T6ZbZK" target="_blank" rel="noopener noreferrer">
+                <li className="item">Contact</li>
+              </a>
+              <Link to={i18n.language === 'ja' ? '/en' : '/'}>
+                <li className="item">
+                  <Translation>{t => t('headerButton')}</Translation>
+                </li>
+              </Link>
+            </ul>
+            <div className="outArea" onClick={this.handleOutAreaClick} />
+          </div>
         </div>
         <div className="padding-area" />
       </div>


### PR DESCRIPTION
close #42 
# 目的
アコーディオンメニューが開いている時、アコーディオンメニューの外をタッチしたら消えて欲しい。

# 解決手法
アコーディオンメニューの下に不可視のタッチ判定を作成し、タッチされたらメニューを消すようにする