### PR TITLE
add: ウィンドウサイズが変わったらアコーディオンメニューを閉じる

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -11,6 +11,8 @@ import { ReduxState } from '../../reducers'
 import { Action, Dispatch } from 'redux'
 import { setIsShowMenu } from '../../actions/header'
 
+const ACCORDION_MENU_CLOSE_WINDOW_WIDTH = 800
+
 type MapDispatchToProps = {
   setIsShowMenu: (isShowMenu: boolean) => void
 }
@@ -26,6 +28,16 @@ class Header extends React.Component<HeaderProps> {
     super(props)
     if (this.props.location.pathname === '/en') {
       i18n.changeLanguage('en')
+    }
+  }
+
+  componentDidMount(): void {
+    window.addEventListener('resize', this.updateDimensions)
+  }
+
+  updateDimensions = () => {
+    if (window.innerWidth > ACCORDION_MENU_CLOSE_WINDOW_WIDTH) {
+      this.props.setIsShowMenu(false)
     }
   }
 


### PR DESCRIPTION
close #46 
# 目的
アコーディオンメニューを開いたまま、ウィンドウサイズを大きくすると、アコーディオンメニューが閉じない。

ウィンドウサイズが一定の大きさを超えたら、アコーディオンメニューは閉じて欲しい

# 解決手法
ウィンドウサイズの変更の検知を受け取り、Headerのハンバーガーボタン表示の閾値を超えたら消すようにした。
