### PR TITLE
change: /enをRedux用にコード改変する

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,18 +9,20 @@ import Footer from './components/Footer'
 import NewsItems from './data/newsItems.json'
 import HelmetWrap from './components/HelmetWrap'
 import ScrollToTop from './components/ScrollToTop'
+import Translator from './containers/Translator'
 
 function App() {
   return (
     <div className="App">
       <HelmetWrap />
       <BrowserRouter basename={process.env.PUBLIC_URL}>
+        <Translator />
         <ScrollToTop>
           <Header />
           <Switch>
-            <Route exact path="/" render={() => <Home items={NewsItems} languageJa={true} />} />
+            <Route exact path="/" render={() => <Home items={NewsItems} />} />
             <Route path="/news" render={() => <News items={NewsItems} />} />
-            <Route exact path="/en" render={() => <Home items={NewsItems} languageJa={false} />} />
+            <Route exact path="/en" render={() => <Home items={NewsItems} />} />
             <Route component={PageNotFound} />
           </Switch>
           <Footer />

--- a/src/actions/translator.tsx
+++ b/src/actions/translator.tsx
@@ -1,0 +1,22 @@
+import { Action } from 'redux'
+import { languageType } from '../types/language'
+
+export enum ActionTypes {
+  SET_LANGUAGE = '@Drip/translator/SET_LANGUAGE',
+}
+
+interface SetLanguage extends Action {
+  type: ActionTypes.SET_LANGUAGE
+  payload: {
+    language: languageType
+  }
+}
+
+export const setLanguage = (language: languageType): SetLanguage => ({
+  type: ActionTypes.SET_LANGUAGE,
+  payload: {
+    language,
+  },
+})
+
+export type TranslatorActions = SetLanguage

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -10,27 +10,24 @@ import { connect } from 'react-redux'
 import { ReduxState } from '../../reducers'
 import { Action, Dispatch } from 'redux'
 import { setIsShowMenu } from '../../actions/header'
+import { languageType } from '../../types/language'
+import {setLanguage} from "../../actions/translator";
 
 const ACCORDION_MENU_CLOSE_WINDOW_WIDTH = 800
 
 type MapDispatchToProps = {
   setIsShowMenu: (isShowMenu: boolean) => void
+  setLanguage: (language: languageType) => void
 }
 
 type MapStateToProps = {
   isShowMenu: boolean
+  language: languageType
 }
 
 type HeaderProps = RouteComponentProps & MapDispatchToProps & MapStateToProps
 
 class Header extends React.Component<HeaderProps> {
-  constructor(props: HeaderProps) {
-    super(props)
-    if (this.props.location.pathname === '/en') {
-      i18n.changeLanguage('en')
-    }
-  }
-
   componentDidMount(): void {
     window.addEventListener('resize', this.updateDimensions)
   }
@@ -52,7 +49,7 @@ class Header extends React.Component<HeaderProps> {
   }
 
   render() {
-    const { isShowMenu } = this.props
+    const { isShowMenu, language } = this.props
     return (
       <div className="Header">
         <div className="fixed-area">
@@ -75,8 +72,8 @@ class Header extends React.Component<HeaderProps> {
                 <a href="https://goo.gl/forms/my00T6ZbZK" target="_blank" rel="noopener noreferrer">
                   <button className="item"> Contact </button>
                 </a>
-                <Link to={i18n.language === 'ja' ? '/en' : '/'}>
-                  <button className="item" onClick={() => this.forceUpdate()}>
+                <Link to={language === 'ja' ? '/en' : '/'}>
+                  <button className="item">
                     <Translation>{t => t('headerButton')}</Translation>
                   </button>
                 </Link>
@@ -94,7 +91,7 @@ class Header extends React.Component<HeaderProps> {
               <a href="https://goo.gl/forms/my00T6ZbZK" target="_blank" rel="noopener noreferrer">
                 <li className="item">Contact</li>
               </a>
-              <Link to={i18n.language === 'ja' ? '/en' : '/'}>
+              <Link to={language === 'ja' ? '/en' : '/'}>
                 <li className="item">
                   <Translation>{t => t('headerButton')}</Translation>
                 </li>
@@ -111,10 +108,12 @@ class Header extends React.Component<HeaderProps> {
 
 const mapStateToProps: (state: ReduxState) => MapStateToProps = state => ({
   isShowMenu: state.header.isShowMenu,
+  language: state.translator.language,
 })
 
 const mapDispatchToProps: (dispatch: Dispatch<Action>) => MapDispatchToProps = dispatch => ({
   setIsShowMenu: isShowMenu => dispatch(setIsShowMenu(isShowMenu)),
+  setLanguage: language => dispatch(setLanguage(language)),
 })
 
 export default connect(

--- a/src/containers/Translator.tsx
+++ b/src/containers/Translator.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react'
+import { languageType } from '../types/language'
+import { connect } from 'react-redux'
+import { ReduxState } from '../reducers'
+import { Action, Dispatch } from 'redux'
+import { RouteComponentProps, withRouter } from 'react-router'
+import i18n from 'i18next'
+import { setLanguage } from '../actions/translator'
+
+type MapDispatchToProps = {
+  setLanguage: (language: languageType) => void
+}
+
+type MapStateToProps = {
+  language: languageType
+}
+
+type TranslatorProps = RouteComponentProps & MapDispatchToProps & MapStateToProps
+
+class Translator extends React.Component<TranslatorProps> {
+  constructor(props: TranslatorProps) {
+    super(props)
+    const { location, setLanguage } = this.props
+    if (location.pathname === '/en') {
+      i18n.changeLanguage('en')
+      setLanguage('en')
+    } else {
+      i18n.changeLanguage('ja')
+      setLanguage('ja')
+    }
+  }
+
+  componentDidUpdate(prevProps: TranslatorProps): void {
+    if (this.props.location !== prevProps.location) {
+      const { location, setLanguage } = this.props
+      if (location.pathname === '/en') {
+        i18n.changeLanguage('en')
+        setLanguage('en')
+      } else {
+        i18n.changeLanguage('ja')
+        setLanguage('ja')
+      }
+    }
+  }
+
+  render() {
+    return null
+  }
+}
+
+const mapStateToProps: (state: ReduxState) => MapStateToProps = state => ({
+  language: state.translator.language,
+})
+
+const mapDispatchToProps: (dispatch: Dispatch<Action>) => MapDispatchToProps = dispatch => ({
+  setLanguage: language => dispatch(setLanguage(language)),
+})
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(withRouter(Translator))

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -5,7 +5,6 @@ import News from '../../components/News'
 import OurInvention from '../../components/OurInvention'
 import Team from '../../components/Team'
 import ContactUs from '../../components/ContactUs'
-import i18n from 'i18next'
 import { connect } from 'react-redux'
 import { setIsShowMenu } from '../../actions/header'
 import { Action, Dispatch } from 'redux'
@@ -16,24 +15,11 @@ type MapDispatchToProps = {
 
 type HomeProps = MapDispatchToProps & {
   items: any[]
-  languageJa: boolean
 }
 
 class Home extends React.Component<HomeProps, {}> {
-  constructor(props: HomeProps) {
-    super(props)
-    i18n.changeLanguage(this.props.languageJa ? 'ja' : 'en')
-  }
-
   componentDidMount(): void {
     this.props.setIsShowMenu(false)
-  }
-
-  componentDidUpdate(prevProps: HomeProps): void {
-    if (this.props.languageJa !== prevProps.languageJa) {
-      this.props.setIsShowMenu(false)
-      i18n.changeLanguage(this.props.languageJa ? 'ja' : 'en')
-    }
   }
 
   render() {

--- a/src/reducers/index.tsx
+++ b/src/reducers/index.tsx
@@ -1,11 +1,14 @@
 import { Reducer, Action, combineReducers } from 'redux'
 import header, { HeaderState } from './header'
+import translator, { TranslatorState } from './translator'
 
 export type ReduxState = {
   header: HeaderState
+  translator: TranslatorState
 }
 
 export const createReducers = (): Reducer<ReduxState, Action> =>
   combineReducers({
     header,
+    translator,
   })

--- a/src/reducers/translator.tsx
+++ b/src/reducers/translator.tsx
@@ -1,0 +1,21 @@
+import { ActionTypes, TranslatorActions } from '../actions/translator'
+import { languageType } from '../types/language'
+
+export type TranslatorState = {
+  language: languageType
+}
+
+export const defaultState: TranslatorState = {
+  language: 'ja',
+}
+
+const Translator = (state: TranslatorState = defaultState, action: TranslatorActions) => {
+  switch (action.type) {
+    case ActionTypes.SET_LANGUAGE:
+      return { ...state, language: action.payload.language }
+    default:
+      return state
+  }
+}
+
+export default Translator

--- a/src/types/language.ts
+++ b/src/types/language.ts
@@ -1,0 +1,1 @@
+export type languageType = 'ja' | 'en'


### PR DESCRIPTION
close #50 
# 目的
/enなど言語切り替え周りのコードが読みづらい

# 解決手法
Reduxを導入したため、現在表示している言語をReduxStateに保たせる。
これにより保守性と可読性を上げる