### PR TITLE
fix: altにあった文字列を正しいものに変更

### DIFF
--- a/src/components/Invention/index.tsx
+++ b/src/components/Invention/index.tsx
@@ -17,9 +17,9 @@ class Invention extends React.Component<InventionProps> {
     return (
       <Slide className={classNames('Invention', className)}>
         <img className="mobile-show-logo" src={smallLogo} alt="smallLogo" />
-        <img className="bigLogo" src={bigLogo} alt="AROW" />
+        <img className="bigLogo" src={bigLogo} alt="bigLogo" />
         <div className="content-area">
-          <img className="smallLogo" src={smallLogo} alt="AROW" />
+          <img className="smallLogo" src={smallLogo} alt="smallLogo" />
           {children}
         </div>
       </Slide>


### PR DESCRIPTION
close #55 
# 目的
Invention/index.tsxは全てのプロダクトが共通して使うはずなのにalt属性にAROWの文字があるのはおかしい

# 解決手法
当たり障りないものに変更