### PR TITLE
fix: icon.pngが404errorしないようにビルド時にimgディレクトリをコピーするようにした

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "postbuild": "react-snap",
+    "postbuild": "react-snap && cp -R build/img build/en/img && cp -R build/img build/news/img",
     "deploy": "bash deploy.sh",
     "test": "react-scripts test",
     "eject": "react-scripts eject",


### PR DESCRIPTION
# 目的
/enページにアクセスするとimg/icon.pngが404エラーしている。

# 解決手法
最初にアクセスされる/en/index.htmlで呼び出されているicon.pngだが、/enディレクトリ下には/imgディレクトリが存在しない。

そこで、/imgを/en/imgにコピーすることで回避する