### PR TITLE
fix: /en/でも英語のページを表示するように変更

### DIFF
--- a/src/containers/Translator.tsx
+++ b/src/containers/Translator.tsx
@@ -21,7 +21,7 @@ class Translator extends React.Component<TranslatorProps> {
   constructor(props: TranslatorProps) {
     super(props)
     const { location, setLanguage } = this.props
-    if (location.pathname === '/en') {
+    if (location.pathname === '/en' || location.pathname === '/en/') {
       i18n.changeLanguage('en')
       setLanguage('en')
     } else {


### PR DESCRIPTION
close #80 
# 目的
/en/にダイレクトアクセスすると日本語のページが出ている。
本来は英語のページが表示される必要がある。

# 解決手法
条件文に/enだけでなく/en/も英語に遷移するように変更する