### PR TITLE
fix: /enや/(日本語)に遷移した時もアコーディオンメニューを閉じる

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -5,13 +5,12 @@ import classNames from 'classnames'
 import { Link, RouteComponentProps, withRouter } from 'react-router-dom'
 import HamburgerButton from '../HamburgerButton'
 import { Translation } from 'react-i18next'
-import i18n from 'i18next'
 import { connect } from 'react-redux'
 import { ReduxState } from '../../reducers'
 import { Action, Dispatch } from 'redux'
 import { setIsShowMenu } from '../../actions/header'
 import { languageType } from '../../types/language'
-import {setLanguage} from "../../actions/translator";
+import { setLanguage } from '../../actions/translator'
 
 const ACCORDION_MENU_CLOSE_WINDOW_WIDTH = 800
 

--- a/src/containers/Translator.tsx
+++ b/src/containers/Translator.tsx
@@ -6,9 +6,11 @@ import { Action, Dispatch } from 'redux'
 import { RouteComponentProps, withRouter } from 'react-router'
 import i18n from 'i18next'
 import { setLanguage } from '../actions/translator'
+import { setIsShowMenu } from '../actions/header'
 
 type MapDispatchToProps = {
   setLanguage: (language: languageType) => void
+  setIsShowMenu: (isShowMenu: boolean) => void
 }
 
 type MapStateToProps = {
@@ -32,7 +34,8 @@ class Translator extends React.Component<TranslatorProps> {
 
   componentDidUpdate(prevProps: TranslatorProps): void {
     if (this.props.location !== prevProps.location) {
-      const { location, setLanguage } = this.props
+      const { location, setLanguage, setIsShowMenu } = this.props
+      setIsShowMenu(false)
       if (location.pathname === '/en') {
         i18n.changeLanguage('en')
         setLanguage('en')
@@ -54,6 +57,7 @@ const mapStateToProps: (state: ReduxState) => MapStateToProps = state => ({
 
 const mapDispatchToProps: (dispatch: Dispatch<Action>) => MapDispatchToProps = dispatch => ({
   setLanguage: language => dispatch(setLanguage(language)),
+  setIsShowMenu: isShowMenu => dispatch(setIsShowMenu(isShowMenu)),
 })
 
 export default connect(


### PR DESCRIPTION
close #83 

# 目的
言語が切り替わった時にもアコーディオンメニューを閉じる
元々そうだったのに、切り替わってなかった

# 解決手法
言語の切り替わりをチェックするTranslatorにてメニューを閉じる処理を追加する