### PR TITLE
fix: 全てのrenderが走る前に言語切り替えの処理を走らせるように変更

### DIFF
--- a/src/containers/Translator.tsx
+++ b/src/containers/Translator.tsx
@@ -32,11 +32,12 @@ class Translator extends React.Component<TranslatorProps> {
     }
   }
 
-  componentDidUpdate(prevProps: TranslatorProps): void {
-    if (this.props.location !== prevProps.location) {
-      const { location, setLanguage, setIsShowMenu } = this.props
+  // 全てのコンポーネントのrender()が走る前に言語切り替えの処理をする必要があるため、WillUpdateに書く
+  componentWillUpdate(nextProps: TranslatorProps): void {
+    if (this.props.location !== nextProps.location) {
+      const { setLanguage, setIsShowMenu } = this.props
       setIsShowMenu(false)
-      if (location.pathname === '/en') {
+      if (nextProps.location.pathname === '/en' || nextProps.location.pathname === '/en/') {
         i18n.changeLanguage('en')
         setLanguage('en')
       } else {


### PR DESCRIPTION
close #87 
# 目的
newsページで英語ボタンを押すと英語のページに行かない

# 解決手法
TranslatorでdidUpdateにてページ遷移検知と言語切り替えをしていたが、
他のコンポーネントがrenderされた後に呼ばれていた。
そこでWillUpdateにて処理をするように変更した