### PR TITLE
change: 2020年のところを2021に変更する

### DIFF
--- a/src/data/language/en.json
+++ b/src/data/language/en.json
@@ -2,7 +2,7 @@
   "topLogoMessage": "Keep Creating Seeds of Innovation!",
   "headerButton": "日本語",
   "missionContent_1": "It's a project to push Drecom to continue inventing new ideas and concepts",
-  "missionContent_2": "As Drecom aims to become a comprehensive entertainment company in 2020, we are developing new businesses in and around entertainment.",
+  "missionContent_2": "As Drecom aims to become a comprehensive entertainment company in 2021, we are developing new businesses in and around entertainment.",
   "missionContent_3": "We aim for bigger and better dreams without fearing failure.",
   "missionContent_4": "",
   "missionContent_5": "We are continually taking on challenges with a small team!",

--- a/src/data/language/ja.json
+++ b/src/data/language/ja.json
@@ -2,7 +2,7 @@
   "topLogoMessage": "発明の種を産み続ける",
   "headerButton": "English",
   "missionContent_1": "ドリコムが常に発明を生み続けるためのProject",
-  "missionContent_2": "2020年は、総合エンターテイメント企業を目指す中、",
+  "missionContent_2": "2021年は、総合エンターテイメント企業を目指す中、",
   "missionContent_3": "その周辺領域にも視野を広げながら、新規事業開発を進めています。",
   "missionContent_4": "小さくヒットではなく、",
   "missionContent_5": "三振してもいいから大振りを",


### PR DESCRIPTION
close #112 
## 概要
タイトル部分にある2020年のところを2021年に変更したい

## 変更箇所
文言を管理している
- src/data/language/en.json
- src/data/language.ja.json

## 手段
編集

## SS
before
<img width="1362" alt="スクリーンショット 2021-01-15 14 15 27" src="https://user-images.githubusercontent.com/52432522/104684418-5d4e5100-573c-11eb-8ee4-4ea6eb60f195.png">
<img width="668" alt="スクリーンショット 2021-01-15 14 15 18" src="https://user-images.githubusercontent.com/52432522/104684422-5f181480-573c-11eb-80d5-24d780c1aabf.png">

after
<img width="1320" alt="スクリーンショット 2021-01-15 14 14 51" src="https://user-images.githubusercontent.com/52432522/104684436-66d7b900-573c-11eb-8c53-dbd45f05265a.png">
<img width="688" alt="スクリーンショット 2021-01-15 14 14 44" src="https://user-images.githubusercontent.com/52432522/104684443-68a17c80-573c-11eb-919d-69f26b57b82a.png">
