### PR TITLE
DRIPページのデザイン変更

### DIFF
--- a/src/components/ContactUs/ContactUs.scss
+++ b/src/components/ContactUs/ContactUs.scss
@@ -1,6 +1,6 @@
 @import "../../utils/vars.scss";
 .ContactUs {
-  background-color: $colorGray;
+  background-color: $colorWhite;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/components/ContactUs/ContactUs.scss
+++ b/src/components/ContactUs/ContactUs.scss
@@ -1,6 +1,7 @@
 @import "../../utils/vars.scss";
 .ContactUs {
   background-color: $colorWhite;
+  border: $colorGray solid 2px;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -24,7 +24,7 @@ const Footer = () => (
         <img className="twitter icon" alt="twitter" src={twitterIcon} />
       </a>
     </div>
-    <p>Copyright 2019 Drecom Co., Ltd. All Rights Reserved.</p>
+    <p>© Drecom Co.,Ltd. All rights Reserved.</p>
   </Slide>
 )
 

--- a/src/components/Member/Member.scss
+++ b/src/components/Member/Member.scss
@@ -1,10 +1,10 @@
 .Member {
-  width: 240px;
+  width: 120px;
   position: relative;
 
   .member-image {
-    width: 240px;
-    height: 240px;
+    width: 120px;
+    height: 120px;
     object-fit: cover;
     object-position: 50% 0;
   }

--- a/src/components/Team/Team.scss
+++ b/src/components/Team/Team.scss
@@ -1,5 +1,6 @@
 @import "../../utils/vars.scss";
 .Team {
+  background-color: $colorGray;
   p {
     text-align: center;
   }

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -25,8 +25,8 @@ class Home extends React.Component<MapDispatchToProps, {}> {
         <Mission />
         <News />
         <OurInvention />
-        <Team />
         <ContactUs />
+        <Team />
       </div>
     )
   }


### PR DESCRIPTION
close #122 

## 概要
DRIPページのデザインを変更したい

## 変更箇所
- Contact us の下に Teamセクションを置くようにする
- Teamの画像を240px->120pxに変更する
- Copyrightをドリコムofficialに合わせる（© Drecom Co.,Ltd. All rights Reserved.）
- Contact usの背景を白に、Teamの背景をグレーにする
- Contact usの上に2pxのグレーborderを追加する

## SS
![localhost_3000_](https://user-images.githubusercontent.com/52432522/111428863-74f58600-873b-11eb-91e3-b4be2dd305a9.png)
