### PR TITLE
ニュース欄の右側に40pxのスペース追加する

### DIFF
--- a/src/components/NewsList/NewsList.scss
+++ b/src/components/NewsList/NewsList.scss
@@ -1,6 +1,7 @@
 .NewsList {
   font-size: 20px;
   font-style: italic;
+  margin-right: 40px;
   li {
     list-style-type: none;
     margin: 1em 0;


### PR DESCRIPTION
close #125 

## 概要
NEWSページの右側にスペースが欲しい

## 変更点
- NEWSページの右側にmargin-right: 40pxを追加

## SS
before
<img width="668" alt="スクリーンショット 2021-03-17 18 05 28" src="https://user-images.githubusercontent.com/52432522/111442140-63b47580-874b-11eb-9918-5d0f6bb6e378.png">


after
<img width="644" alt="スクリーンショット 2021-03-17 18 05 14" src="https://user-images.githubusercontent.com/52432522/111442164-68792980-874b-11eb-849c-079cf78efb10.png">

