### PR TITLE
change: topにのみborderを当てる

### DIFF
--- a/src/components/ContactUs/ContactUs.scss
+++ b/src/components/ContactUs/ContactUs.scss
@@ -1,7 +1,7 @@
 @import "../../utils/vars.scss";
 .ContactUs {
   background-color: $colorWhite;
-  border: $colorGray solid 2px;
+  border-top: $colorGray solid 2px;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
#122 

## 概要
#122 の変更点では、ContactUsの部分に当てるborderは上にだけ当てる必要があったので修正する

## SS
わかりづらいので、色つけ状態でスクリーンショットです。

before
<img width="778" alt="スクリーンショット 2021-03-18 12 40 56" src="https://user-images.githubusercontent.com/52432522/111570102-6664a880-87e7-11eb-91ec-c5cdf45b95f6.png">

after
<img width="784" alt="スクリーンショット 2021-03-18 12 41 19" src="https://user-images.githubusercontent.com/52432522/111570112-6c5a8980-87e7-11eb-9627-06d284bcf2fb.png">
