### PR TITLE
本番更新2021/9/15 16:30

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,41 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches:
+      - release
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/release' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build

--- a/README.md
+++ b/README.md
@@ -206,42 +206,12 @@ render() {
 できるだけ `any` は使わず、型を与えてください。
 
 ## デプロイ手順（ドリップページの公開方法）
-### 手順
-1. masterブランチにてbuildする。
-1. 生成されたbuildディレクトリごと、どこかへ退避しておく。
-1. gh-pagesブランチから新しくブランチを作成する。
-1. drip-officialディレクトリの中身を **以下のファイルを除き** 削除する。
-1. buildディレクトリ内の全てのファイルをdrip-officialディレクトリにコピペする。
-1. コミット、プッシュしたのち、github.comにてgh-pagesブランチにマージするプルリクエストを作成する。
-1. ページを構成するために必要なファイルが全て揃っているか確認する
-    1. gh-pagesから作成したgh-pages-xxブランチをローカルから一時削除する
-    1. gh-pages-xxブランチをgithubよりpullする
-    1. http-serverなどのコマンドを使い、ブラウザ表示して確認する (ex:`$ http-server ./drip-official`)
-1. github.comにてgh-pagesブランチにマージする。
-
-http-serverについてはこちら
-https://www.npmjs.com/package/http-server
+1. masterブランチからreleaseブランチに対してpull requestを作成する。
+1. 必要な人にレビューしてもらい、問題なければMerge pull requestボタンを押す。
+1. GitHub　Actionsが走り出し、デプロイが実施される。
 
 ### 諸注意
 浸透まで時間がかかり、完全に浸透し切るまで画像が表示されないことがあった。
 その時は38分後、画像が表示されるようになった。
 https://github.com/drip-pages/drip-official/issues/110
 （地域差で浸透時間が変わっているような）
-
-削除しないファイル（ディレクトリ）
-```
-CNAME
-pp.txt
-.gitignore
-.git
-```
-
-# Q & A
-## Q: なぜdrip-officialディレクトリの中身を一度削除するのか。
-
-### A: 生成されるファイルのいくつかが自動生成されたファイル名をつけられるためです。
-そのため、一度削除してしまったほうが作業が簡単です。
-
-また、
-自動生成されたファイル名がつけられたファイルと削除した画像やページ(htmlファイルなど)を削除したのち、
-ドラックアンドドロップで上書きでも問題ありません。


### PR DESCRIPTION
## 概要
GitHub Actionsを利用してデプロイを走らせるためだけのPRです。
ユーザー影響はありません。

本PRをマージすることでGitHub Actionsが動き出し、デプロイ作業を実施してくれるはずです。

## 変更履歴
- https://github.com/drip-pages/drip-official/pull/137 GitHub Actionsを利用してデプロイ実施するようにする

## その他
もし、ページが表示されないなどの問題が発生した場合は、バックアップしているファイルをgh-pagesに入れるPRを作成して、元に戻します。