### PR TITLE
gh-pages.ymlのDeployジョブにcnameを追加する

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -39,3 +39,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build
+          cname: drip.drecom.co.jp


### PR DESCRIPTION
#136 
## 概要
デプロイは成功したが、カスタムドメインが外れてしまった。
詳細は以下を参照
https://github.com/drip-pages/drip-official/issues/136#issuecomment-919780594

デプロイするときにカスタムドメインを設定して欲しい

## 手順
https://qiita.com/peaceiris/items/d401f2e5724fdcb0759d
https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-add-cname-file-cname
を参考に`cname`を設定する。

## 動作確認
別のリポジトリで試してみたところうまく設定されていることを確認した。

▼テスト時のPR
https://github.com/fukui-takanori/ogp-tester/pull/5/files

▼別リポジトリの設定ページ
https://github.com/fukui-takanori/ogp-tester/settings/pages
<img width="779" alt="スクリーンショット 2021-09-15 17 10 57" src="https://user-images.githubusercontent.com/52432522/133396760-a24a801c-f081-4920-9c9c-ef7d195a362c.png">
