### PR TITLE
CNAME 復活

### DIFF
--- a/200.html
+++ b/200.html
@@ -1,0 +1,5 @@
+---
+layout: redirected
+sitemap: false
+redirect_to: https://drecom.co.jp/
+---

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-drip.drecom.co.jp
+drecom.co.jp

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+drip.drecom.co.jp


### PR DESCRIPTION
# Why

#145 
https://drip.drecom.co.jp/ だと Github の用意した 404 ページが表示されてしまった。
元々のドメインである https://drip-pages.github.io/drip-official/ の方は期待通りリダイレクトされた。
前者でもリダイレクトするようにしたい。

# How

### CNAME 復活

https://docs.github.com/ja/pages/configuring-a-custom-domain-for-your-github-pages-site/troubleshooting-custom-domains-and-github-pages
復活させつつ、CNAME 先をリダイレクト先にしてみました。